### PR TITLE
Allows cors

### DIFF
--- a/setup_app.py
+++ b/setup_app.py
@@ -40,6 +40,8 @@ def setup_app(app_config):
         def __init__(self, *args, **kwargs):
             super(JsonDefault, self).__init__(*args, **kwargs)
             self.mimetype = 'application/json'
+            self.headers['Access-Control-Allow-Origin'] = '*'
+            self.headers['Access-Control-Allow-Headers'] = '*'
 
     app.response_class = JsonDefault
 


### PR DESCRIPTION
Enable clients, which are hosted under a different domain than this api to make requests without browser warnings.